### PR TITLE
Harden device registration script

### DIFF
--- a/setup/setup-media-pi.sh
+++ b/setup/setup-media-pi.sh
@@ -17,13 +17,26 @@ SSH_USER_ON_PI="pi"  # user on the device under which the agent runs, shall matc
 SSH_KEY_PATH="/home/${SSH_USER_ON_PI}/.ssh"
 PUBKEY_PATH="${SSH_KEY_PATH}/id_ed25519.pub"
 PRIVKEY_PATH="${SSH_KEY_PATH}/id_ed25519"
+AUTHORIZED_KEYS_PATH="${SSH_KEY_PATH}/authorized_keys"
 
 apt-get update
 apt-get install -y curl openssh-client jq
 
-# Ensure device key exists
+# Ensure SSH directory and device key exist
+install -d -m 700 -o "${SSH_USER_ON_PI}" -g "${SSH_USER_ON_PI}" "${SSH_KEY_PATH}"
+
 if [[ ! -f ${PRIVKEY_PATH} ]]; then
   ssh-keygen -t ed25519 -N "" -f "${PRIVKEY_PATH}"
+fi
+
+if [[ -f ${PRIVKEY_PATH} ]]; then
+  chown "${SSH_USER_ON_PI}:${SSH_USER_ON_PI}" "${PRIVKEY_PATH}"
+  chmod 600 "${PRIVKEY_PATH}"
+fi
+
+if [[ -f ${PUBKEY_PATH} ]]; then
+  chown "${SSH_USER_ON_PI}:${SSH_USER_ON_PI}" "${PUBKEY_PATH}"
+  chmod 644 "${PUBKEY_PATH}"
 fi
 
 # Prepare metadata
@@ -34,14 +47,49 @@ PUBKEY_CONTENT=$(cat "${PUBKEY_PATH}")
 # Enroll / register (idempotent upsert)
 echo "Enrolling device at ${CORE_API_BASE}/devices/register ..."
 DEVICE_IP=$(hostname -I | awk '{print $1}')
-RESP=$(
-  curl -sS -X POST "${CORE_API_BASE}/devices/register" \
+if ! RESP=$(
+  curl -sS --fail-with-body -X POST "${CORE_API_BASE}/devices/register" \
     -H 'Content-Type: application/json' \
     -d @<(jq -n --arg pk "$PUBKEY_CONTENT" \
               --arg hn "$HOSTNAME" \
               --arg su "$SSH_USER_ON_PI" \
               --arg ip "$DEVICE_IP" \
               '{ publicKeyOpenSsh: $pk, name: $hn, ipAddress: $ip, sshUser: $su }')
-)
-echo "Enroll response: ${RESP}"
+); then
+  echo "Error: device registration request failed" >&2
+  exit 1
+fi
+if [[ -z "${RESP}" ]]; then
+  echo "Error: empty response from device registration" >&2
+  exit 1
+fi
+
+DEVICE_ID=$(jq -r '.id // .Id // empty' <<<"${RESP}" || true)
+if [[ -n "${DEVICE_ID}" ]]; then
+  echo "Device registered with ID ${DEVICE_ID}."
+else
+  echo "Device registration response did not include an ID."
+fi
+
+if ! SERVER_PUBLIC_SSH_KEY=$(jq -er '.serverPublicSshKey' <<<"${RESP}" 2>/dev/null); then
+  echo "Error: serverPublicSshKey is missing in the enrollment response" >&2
+  exit 1
+fi
+
+# Ensure authorized_keys exists with correct permissions
+if [[ ! -f "${AUTHORIZED_KEYS_PATH}" ]]; then
+  install -m 600 -o "${SSH_USER_ON_PI}" -g "${SSH_USER_ON_PI}" /dev/null "${AUTHORIZED_KEYS_PATH}"
+else
+  chown "${SSH_USER_ON_PI}:${SSH_USER_ON_PI}" "${AUTHORIZED_KEYS_PATH}"
+  chmod 600 "${AUTHORIZED_KEYS_PATH}"
+fi
+
+if grep -qxF "${SERVER_PUBLIC_SSH_KEY}" "${AUTHORIZED_KEYS_PATH}"; then
+  echo "Server public SSH key already present in ${AUTHORIZED_KEYS_PATH}"
+else
+  printf '%s\n' "${SERVER_PUBLIC_SSH_KEY}" >>"${AUTHORIZED_KEYS_PATH}"
+  echo "Appended server public SSH key to ${AUTHORIZED_KEYS_PATH}"
+fi
+
+echo "serverPublicSshKey: ${SERVER_PUBLIC_SSH_KEY}"
 

--- a/setup/setup-media-pi.sh
+++ b/setup/setup-media-pi.sh
@@ -71,7 +71,7 @@ else
   echo "Device registration response did not include an ID."
 fi
 
-if ! SERVER_PUBLIC_SSH_KEY=$(jq -er '.serverPublicSshKey' <<<"${RESP}" 2>/dev/null); then
+if ! SERVER_PUBLIC_SSH_KEY=$(jq -er '.serverPublicSshKey' <<<"${RESP}"); then
   echo "Error: serverPublicSshKey is missing in the enrollment response" >&2
   exit 1
 fi

--- a/setup/setup-media-pi.sh
+++ b/setup/setup-media-pi.sh
@@ -64,7 +64,7 @@ if [[ -z "${RESP}" ]]; then
   exit 1
 fi
 
-DEVICE_ID=$(jq -r '.id // .Id // empty' <<<"${RESP}" || true)
+DEVICE_ID=$(jq -r '.id // empty' <<<"${RESP}" || true)
 if [[ -n "${DEVICE_ID}" ]]; then
   echo "Device registered with ID ${DEVICE_ID}."
 else


### PR DESCRIPTION
## Summary
- ensure the setup script provisions the ~/.ssh directory for the agent user and normalizes key ownership and permissions
- add error handling around device registration, report the assigned device ID, and enforce that the response carries serverPublicSshKey
- create or update authorized_keys with the right owner/mode before idempotently appending the server's SSH key

## Testing
- go test ./... *(hangs in this container; interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68cd8c6a20c48321a95d112ca82a1673