### PR TITLE
Add unified configuration endpoints

### DIFF
--- a/cmd/media-pi/main.go
+++ b/cmd/media-pi/main.go
@@ -74,7 +74,7 @@ func main() {
 	mux.HandleFunc("/api/menu/playback/start", agent.AuthMiddleware(agent.HandlePlaybackStart))
 	mux.HandleFunc("/api/menu/service/status", agent.AuthMiddleware(agent.HandleServiceStatus))
 	mux.HandleFunc("/api/menu/configuration/get", agent.AuthMiddleware(agent.HandleConfigurationGet))
-	mux.HandleFunc("/api/menu/configuration/upload", agent.AuthMiddleware(agent.HandleConfigurationUpload))
+	mux.HandleFunc("/api/menu/configuration/update", agent.AuthMiddleware(agent.HandleConfigurationUpdate))
 	mux.HandleFunc("/api/menu/playlist/start-upload", agent.AuthMiddleware(agent.HandlePlaylistStartUpload))
 	mux.HandleFunc("/api/menu/playlist/stop-upload", agent.AuthMiddleware(agent.HandlePlaylistStopUpload))
 	mux.HandleFunc("/api/menu/system/reload", agent.AuthMiddleware(agent.HandleSystemReload))

--- a/internal/agent/menu.go
+++ b/internal/agent/menu.go
@@ -123,11 +123,11 @@ func GetMenuActions() []MenuAction {
 			Path:        "/api/menu/configuration/get",
 		},
 		{
-			ID:          "configuration-upload",
+			ID:          "configuration-update",
 			Name:        "Обновить конфигурацию",
 			Description: "Обновить конфигурацию плейлиста, расписания и аудио",
 			Method:      "PUT",
-			Path:        "/api/menu/configuration/upload",
+			Path:        "/api/menu/configuration/update",
 		},
 		{
 			ID:          "playlist-start-upload",
@@ -598,8 +598,8 @@ func HandleConfigurationGet(w http.ResponseWriter, r *http.Request) {
 	}})
 }
 
-// HandleConfigurationUpload updates playlist upload paths, schedule timers and audio output together.
-func HandleConfigurationUpload(w http.ResponseWriter, r *http.Request) {
+// HandleConfigurationUpdate updates playlist upload paths, schedule timers and audio output together.
+func HandleConfigurationUpdate(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPut {
 		JSONResponse(w, http.StatusMethodNotAllowed, APIResponse{OK: false, ErrMsg: "Метод не разрешён"})
 		return
@@ -671,7 +671,7 @@ func HandleConfigurationUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	JSONResponse(w, http.StatusOK, APIResponse{OK: true, Data: MenuActionResponse{Action: "configuration-upload", Result: "success", Message: "Конфигурация обновлена"}})
+	JSONResponse(w, http.StatusOK, APIResponse{OK: true, Data: MenuActionResponse{Action: "configuration-update", Result: "success", Message: "Конфигурация обновлена"}})
 }
 
 // HandleSystemReload reloads systemd daemon configuration.

--- a/internal/agent/menu_test.go
+++ b/internal/agent/menu_test.go
@@ -96,7 +96,7 @@ func TestGetMenuActions(t *testing.T) {
 		"playback-start",
 		"service-status",
 		"configuration-get",
-		"configuration-upload",
+		"configuration-update",
 		"playlist-start-upload",
 		"playlist-stop-upload",
 		"system-reload",
@@ -267,13 +267,13 @@ func TestHandleConfigurationGetMethodNotAllowed(t *testing.T) {
 	}
 }
 
-func TestHandleConfigurationUploadMethodNotAllowed(t *testing.T) {
+func TestHandleConfigurationUpdateMethodNotAllowed(t *testing.T) {
 	ServerKey = "test-key"
-	req := httptest.NewRequest(http.MethodGet, "/api/menu/configuration/upload", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/menu/configuration/update", nil)
 	req.Header.Set("Authorization", "Bearer test-key")
 	w := httptest.NewRecorder()
 
-	HandleConfigurationUpload(w, req)
+	HandleConfigurationUpdate(w, req)
 
 	if w.Code != http.StatusMethodNotAllowed {
 		t.Errorf("expected status 405, got %d", w.Code)
@@ -453,11 +453,11 @@ WantedBy = multi-user.target
 	})
 
 	body := `{"playlist":{"source":"/mnt/ya.disk/playlist/test/","destination":"/mnt/usb/playlist/"},"schedule":{"playlist":["6:05","16:28"],"video":["22:22"],"rest":[{"start":"12:00","stop":"13:00"},{"start":"23:45","stop":"07:00"}]},"audio":{"output":"jack"}}`
-	req := httptest.NewRequest(http.MethodPut, "/api/menu/configuration/upload", strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPut, "/api/menu/configuration/update", strings.NewReader(body))
 	req.Header.Set("Authorization", "Bearer test-key")
 	w := httptest.NewRecorder()
 
-	HandleConfigurationUpload(w, req)
+	HandleConfigurationUpdate(w, req)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
@@ -529,11 +529,11 @@ func TestHandleConfigurationUploadValidation(t *testing.T) {
 	}
 
 	body := `{"playlist":{"source":"","destination":"/mnt/usb"},"schedule":{"playlist":["25:00"],"video":["08:00"],"rest":[]},"audio":{"output":"invalid"}}`
-	req := httptest.NewRequest(http.MethodPut, "/api/menu/configuration/upload", strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPut, "/api/menu/configuration/update", strings.NewReader(body))
 	req.Header.Set("Authorization", "Bearer test-key")
 	w := httptest.NewRecorder()
 
-	HandleConfigurationUpload(w, req)
+	HandleConfigurationUpdate(w, req)
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", w.Code)
@@ -636,11 +636,11 @@ func TestHandleConfigurationUploadRejectsInvalidRestIntervals(t *testing.T) {
 	})
 
 	body := `{"playlist":{"source":"/a","destination":"/b"},"schedule":{"playlist":["6:05"],"video":["22:22"],"rest":[{"start":"10:00","stop":"12:00"},{"start":"11:00","stop":"13:00"}]},"audio":{"output":"hdmi"}}`
-	req := httptest.NewRequest(http.MethodPut, "/api/menu/configuration/upload", strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPut, "/api/menu/configuration/update", strings.NewReader(body))
 	req.Header.Set("Authorization", "Bearer test-key")
 	w := httptest.NewRecorder()
 
-	HandleConfigurationUpload(w, req)
+	HandleConfigurationUpdate(w, req)
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", w.Code)
@@ -656,7 +656,7 @@ func TestGetMenuActionsIncludesNewActions(t *testing.T) {
 
 	expectedIDs := []string{
 		"configuration-get",
-		"configuration-upload",
+		"configuration-update",
 		"playlist-start-upload",
 		"playlist-stop-upload",
 	}


### PR DESCRIPTION
## Summary
- replace playlist, schedule, and audio menu endpoints with consolidated configuration handlers and DTO
- register new configuration routes in the HTTP server
- refresh menu handler tests to cover the combined configuration API and validations

## Testing
- go test ./internal/... ./cmd/...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b2f7edfb88321b75ab0a65d089c21)