### PR TITLE
Persist configuration snapshots on get/update

### DIFF
--- a/setup/setup-media-pi.sh
+++ b/setup/setup-media-pi.sh
@@ -142,6 +142,13 @@ if systemctl is-active --quiet media-pi-agent.service; then
   else
     echo "⚠ Warning: REST API not responding on port ${AGENT_PORT}"
   fi
+
+  echo "Generating configuration snapshot..."
+  if ! curl -sSf -H "Authorization: Bearer ${SERVER_KEY}" \
+    "http://localhost:${AGENT_PORT}/api/menu/configuration/get" >/dev/null; then
+    echo "✗ Error: Failed to generate configuration snapshot" >&2
+    exit 1
+  fi
 else
   echo "✗ Error: Media Pi Agent service failed to start" >&2
   systemctl status media-pi-agent.service >&2


### PR DESCRIPTION
### Motivation
- Persist the aggregated runtime configuration to a stable file so applied configuration can be inspected later.  
- Ensure the agent generates that persisted configuration at install/setup time so the system has a config file without requiring a manual `configuration-get` call.  
- Make the snapshot format YAML and keep tests able to override paths for isolation.  
- Add unit tests to validate snapshot persistence alongside existing configuration handlers.

### Description
- Add `ConfigurationSnapshotPath` (default `"/etc/media-pi-agent/config.yaml"`) and YAML tagging to `ConfigurationSettings`, `PlaylistUploadConfig`, `ScheduleSettings`, `AudioSettings`, and `RestTimePair`.  
- Implement `persistConfigurationSettings(settings ConfigurationSettings)` to marshal settings to YAML and write them to `ConfigurationSnapshotPath`.  
- Call `persistConfigurationSettings` from `HandleConfigurationGet` and `HandleConfigurationUpdate` so snapshots are written after reads and updates.  
- Update `setup/setup-media-pi.sh` to request the `GET /api/menu/configuration/get` endpoint after the service starts to generate the configuration snapshot, and extend unit tests (`internal/agent/menu_test.go`) to assert the snapshot file contents.

### Testing
- Ran unit tests with `go test ./...` and package tests passed (`ok` for `cmd/media-pi` and `internal/agent`).  
- `golangci-lint run ./...` failed due to an environment mismatch where `golangci-lint` was built with Go 1.24 but the project targets Go 1.25.1.  
- `shellcheck setup/setup-media-pi.sh` could not run because `shellcheck` was not installed in the environment.  
- Added unit test assertions that read and unmarshal the generated snapshot and those tests passed as part of the `go test` run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ef197c58c832185dbaae691ccc685)