### PR TITLE
Add screenshot settings to configuration API and scheduler

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -50,20 +50,27 @@ type AudioConfig struct {
 	Output string `yaml:"output,omitempty" json:"output,omitempty"`
 }
 
+// ScreenshotConfig describes periodic screenshot capture settings.
+type ScreenshotConfig struct {
+	IntervalMinutes int    `yaml:"interval_minutes,omitempty" json:"interval_minutes,omitempty"`
+	PathTemplate    string `yaml:"path_template,omitempty" json:"path_template,omitempty"`
+}
+
 // Config represents the agent configuration file structure. It is loaded
 // from YAML and contains the list of allowed systemd units, the server
 // authentication key and the listen address for the HTTP API, as well as
 // all configuration settings that were previously stored only in systemd unit files.
 type Config struct {
-	AllowedUnits         []string       `yaml:"allowed_units"`
-	ServerKey            string         `yaml:"server_key,omitempty"`
-	ListenAddr           string         `yaml:"listen_addr,omitempty"`
-	MediaPiServiceUser   string         `yaml:"media_pi_service_user,omitempty"`
-	CoreAPIBase          string         `yaml:"core_api_base,omitempty"`
-	MaxParallelDownloads int            `yaml:"max_parallel_downloads,omitempty"`
-	Playlist             PlaylistConfig `yaml:"playlist,omitempty"`
-	Schedule             ScheduleConfig `yaml:"schedule,omitempty"`
-	Audio                AudioConfig    `yaml:"audio,omitempty"`
+	AllowedUnits         []string         `yaml:"allowed_units"`
+	ServerKey            string           `yaml:"server_key,omitempty"`
+	ListenAddr           string           `yaml:"listen_addr,omitempty"`
+	MediaPiServiceUser   string           `yaml:"media_pi_service_user,omitempty"`
+	CoreAPIBase          string           `yaml:"core_api_base,omitempty"`
+	MaxParallelDownloads int              `yaml:"max_parallel_downloads,omitempty"`
+	Playlist             PlaylistConfig   `yaml:"playlist,omitempty"`
+	Schedule             ScheduleConfig   `yaml:"schedule,omitempty"`
+	Audio                AudioConfig      `yaml:"audio,omitempty"`
+	Screenshot           ScreenshotConfig `yaml:"screenshot,omitempty"`
 }
 
 // APIResponse is the standard envelope used by HTTP handlers to return
@@ -157,6 +164,9 @@ func DefaultConfig() Config {
 		Playlist: PlaylistConfig{
 			Destination: "/var/media-pi",
 		},
+		Screenshot: ScreenshotConfig{
+			PathTemplate: "/home/pi/Pictures/cam_$(date +%F_%H-%M-%S).jpg",
+		},
 	}
 }
 
@@ -203,6 +213,11 @@ func LoadConfigFrom(path string) (*Config, error) {
 		c.MaxParallelDownloads = 3
 	}
 
+	// Set default screenshot path template if not specified.
+	if strings.TrimSpace(c.Screenshot.PathTemplate) == "" {
+		c.Screenshot.PathTemplate = "/home/pi/Pictures/cam_$(date +%F_%H-%M-%S).jpg"
+	}
+
 	// Set global variables before migration (which may need them)
 	AllowedUnits = newAllowedUnits
 	ServerKey = c.ServerKey
@@ -243,7 +258,7 @@ func GetCurrentConfig() Config {
 
 // UpdateConfigSettings updates the configuration settings in memory and saves to file.
 // This function is thread-safe. After saving, it signals the scheduler to reload.
-func UpdateConfigSettings(playlist PlaylistConfig, schedule ScheduleConfig, audio AudioConfig) error {
+func UpdateConfigSettings(playlist PlaylistConfig, schedule ScheduleConfig, audio AudioConfig, screenshot ScreenshotConfig) error {
 	configMutex.Lock()
 	defer configMutex.Unlock()
 
@@ -255,6 +270,7 @@ func UpdateConfigSettings(playlist PlaylistConfig, schedule ScheduleConfig, audi
 	currentConfig.Playlist = playlist
 	currentConfig.Schedule = schedule
 	currentConfig.Audio = audio
+	currentConfig.Screenshot = screenshot
 
 	// Save to file
 	if ConfigPath == "" {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -131,6 +131,9 @@ var (
 // listen address for the HTTP API.
 const DefaultListenAddr = "0.0.0.0:8081"
 
+// DefaultScreenshotPathTemplate is used when screenshot path template is not configured.
+const DefaultScreenshotPathTemplate = "/home/pi/Pictures/cam_$(date +%F_%H-%M-%S).jpg"
+
 // Version can be set at build time with -ldflags
 var Version = "unknown"
 
@@ -165,7 +168,7 @@ func DefaultConfig() Config {
 			Destination: "/var/media-pi",
 		},
 		Screenshot: ScreenshotConfig{
-			PathTemplate: "/home/pi/Pictures/cam_$(date +%F_%H-%M-%S).jpg",
+			PathTemplate: DefaultScreenshotPathTemplate,
 		},
 	}
 }
@@ -215,7 +218,7 @@ func LoadConfigFrom(path string) (*Config, error) {
 
 	// Set default screenshot path template if not specified.
 	if strings.TrimSpace(c.Screenshot.PathTemplate) == "" {
-		c.Screenshot.PathTemplate = "/home/pi/Pictures/cam_$(date +%F_%H-%M-%S).jpg"
+		c.Screenshot.PathTemplate = DefaultScreenshotPathTemplate
 	}
 
 	// Set global variables before migration (which may need them)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -54,6 +54,7 @@ type AudioConfig struct {
 type ScreenshotConfig struct {
 	IntervalMinutes int    `yaml:"interval_minutes,omitempty" json:"interval_minutes,omitempty"`
 	PathTemplate    string `yaml:"path_template,omitempty" json:"path_template,omitempty"`
+	Input           string `yaml:"input,omitempty" json:"input,omitempty"`
 }
 
 // Config represents the agent configuration file structure. It is loaded
@@ -134,6 +135,9 @@ const DefaultListenAddr = "0.0.0.0:8081"
 // DefaultScreenshotPathTemplate is used when screenshot path template is not configured.
 const DefaultScreenshotPathTemplate = "/home/pi/Pictures/cam_$(date +%F_%H-%M-%S).jpg"
 
+// DefaultScreenshotInput is used when screenshot input source is not configured.
+const DefaultScreenshotInput = "/dev/video0"
+
 // Version can be set at build time with -ldflags
 var Version = "unknown"
 
@@ -169,6 +173,7 @@ func DefaultConfig() Config {
 		},
 		Screenshot: ScreenshotConfig{
 			PathTemplate: DefaultScreenshotPathTemplate,
+			Input:        DefaultScreenshotInput,
 		},
 	}
 }
@@ -219,6 +224,9 @@ func LoadConfigFrom(path string) (*Config, error) {
 	// Set default screenshot path template if not specified.
 	if strings.TrimSpace(c.Screenshot.PathTemplate) == "" {
 		c.Screenshot.PathTemplate = DefaultScreenshotPathTemplate
+	}
+	if strings.TrimSpace(c.Screenshot.Input) == "" {
+		c.Screenshot.Input = DefaultScreenshotInput
 	}
 
 	// Set global variables before migration (which may need them)

--- a/internal/agent/config_migration_test.go
+++ b/internal/agent/config_migration_test.go
@@ -212,7 +212,7 @@ func TestMigrateConfigFromSystemd_HandlesErrors(t *testing.T) {
 	cfg := Config{}
 	needsSave := false
 	err := migrateConfigFromSystemd(&cfg, &needsSave)
-	
+
 	// Should return error but not crash
 	if err == nil {
 		t.Errorf("expected error when files don't exist")
@@ -227,11 +227,11 @@ func TestMigrateConfigFromSystemd_HandlesErrors(t *testing.T) {
 func TestGetCurrentConfig(t *testing.T) {
 	// Set up test config
 	testConfig := &Config{
-		AllowedUnits:       []string{"test.service"},
-		ServerKey:          "test-key",
-		Playlist:           PlaylistConfig{Source: "/src", Destination: "/dst"},
-		Schedule:           ScheduleConfig{Playlist: []string{"10:00"}},
-		Audio:              AudioConfig{Output: "hdmi"},
+		AllowedUnits: []string{"test.service"},
+		ServerKey:    "test-key",
+		Playlist:     PlaylistConfig{Source: "/src", Destination: "/dst"},
+		Schedule:     ScheduleConfig{Playlist: []string{"10:00"}},
+		Audio:        AudioConfig{Output: "hdmi"},
 	}
 
 	configMutex.Lock()
@@ -247,7 +247,7 @@ func TestGetCurrentConfig(t *testing.T) {
 
 	// Get config and verify it's a copy
 	cfg := GetCurrentConfig()
-	
+
 	if cfg.ServerKey != "test-key" {
 		t.Errorf("expected server key test-key, got %s", cfg.ServerKey)
 	}
@@ -295,6 +295,7 @@ func TestUpdateConfigSettings(t *testing.T) {
 		PlaylistConfig{Source: "/new/src", Destination: "/new/dst"},
 		ScheduleConfig{Playlist: []string{"12:00"}, Video: []string{"18:00"}},
 		AudioConfig{Output: "analog"},
+		ScreenshotConfig{IntervalMinutes: 15, PathTemplate: "/home/pi/Pictures/cam_$(date +%F_%H-%M-%S).jpg"},
 	)
 	if err != nil {
 		t.Fatalf("UpdateConfigSettings failed: %v", err)
@@ -308,6 +309,9 @@ func TestUpdateConfigSettings(t *testing.T) {
 	if cfg.Audio.Output != "analog" {
 		t.Errorf("expected audio analog, got %s", cfg.Audio.Output)
 	}
+	if cfg.Screenshot.IntervalMinutes != 15 {
+		t.Errorf("expected screenshot interval 15, got %d", cfg.Screenshot.IntervalMinutes)
+	}
 
 	// Verify file was created and can be loaded
 	loadedCfg, err := LoadConfigFrom(configPath)
@@ -319,6 +323,9 @@ func TestUpdateConfigSettings(t *testing.T) {
 	}
 	if len(loadedCfg.Schedule.Video) != 1 || loadedCfg.Schedule.Video[0] != "18:00" {
 		t.Errorf("saved config has wrong video schedule: %v", loadedCfg.Schedule.Video)
+	}
+	if loadedCfg.Screenshot.IntervalMinutes != 15 {
+		t.Errorf("saved config has wrong screenshot interval: %d", loadedCfg.Screenshot.IntervalMinutes)
 	}
 }
 
@@ -338,6 +345,7 @@ func TestUpdateConfigSettings_NoCurrentConfig(t *testing.T) {
 		PlaylistConfig{},
 		ScheduleConfig{},
 		AudioConfig{},
+		ScreenshotConfig{},
 	)
 
 	if err == nil {

--- a/internal/agent/config_migration_test.go
+++ b/internal/agent/config_migration_test.go
@@ -295,7 +295,7 @@ func TestUpdateConfigSettings(t *testing.T) {
 		PlaylistConfig{Source: "/new/src", Destination: "/new/dst"},
 		ScheduleConfig{Playlist: []string{"12:00"}, Video: []string{"18:00"}},
 		AudioConfig{Output: "analog"},
-		ScreenshotConfig{IntervalMinutes: 15, PathTemplate: "/home/pi/Pictures/cam_$(date +%F_%H-%M-%S).jpg"},
+		ScreenshotConfig{IntervalMinutes: 15, PathTemplate: "/home/pi/Pictures/cam_$(date +%F_%H-%M-%S).jpg", Input: "/dev/video2"},
 	)
 	if err != nil {
 		t.Fatalf("UpdateConfigSettings failed: %v", err)
@@ -312,6 +312,9 @@ func TestUpdateConfigSettings(t *testing.T) {
 	if cfg.Screenshot.IntervalMinutes != 15 {
 		t.Errorf("expected screenshot interval 15, got %d", cfg.Screenshot.IntervalMinutes)
 	}
+	if cfg.Screenshot.Input != "/dev/video2" {
+		t.Errorf("expected screenshot input /dev/video2, got %q", cfg.Screenshot.Input)
+	}
 
 	// Verify file was created and can be loaded
 	loadedCfg, err := LoadConfigFrom(configPath)
@@ -326,6 +329,9 @@ func TestUpdateConfigSettings(t *testing.T) {
 	}
 	if loadedCfg.Screenshot.IntervalMinutes != 15 {
 		t.Errorf("saved config has wrong screenshot interval: %d", loadedCfg.Screenshot.IntervalMinutes)
+	}
+	if loadedCfg.Screenshot.Input != "/dev/video2" {
+		t.Errorf("saved config has wrong screenshot input: %q", loadedCfg.Screenshot.Input)
 	}
 }
 

--- a/internal/agent/menu.go
+++ b/internal/agent/menu.go
@@ -214,6 +214,15 @@ type ConfigurationSettings struct {
 	Screenshot ScreenshotSettings   `json:"screenshot"`
 }
 
+// configurationUpdateRequest mirrors ConfigurationSettings but keeps Screenshot as a pointer
+// to preserve backwards compatibility with clients that omit the screenshot object.
+type configurationUpdateRequest struct {
+	Playlist   PlaylistUploadConfig `json:"playlist"`
+	Schedule   ScheduleSettings     `json:"schedule"`
+	Audio      AudioSettings        `json:"audio"`
+	Screenshot *ScreenshotSettings  `json:"screenshot,omitempty"`
+}
+
 // ServiceStatusResponse describes the service status returned by the
 // service-status endpoint.
 type ServiceStatusResponse struct {
@@ -612,7 +621,7 @@ func HandleConfigurationUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var req ConfigurationSettings
+	var req configurationUpdateRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		JSONResponse(w, http.StatusBadRequest, APIResponse{OK: false, ErrMsg: "Неверный JSON в теле запроса"})
 		return
@@ -649,7 +658,11 @@ func HandleConfigurationUpdate(w http.ResponseWriter, r *http.Request) {
 		JSONResponse(w, http.StatusBadRequest, APIResponse{OK: false, ErrMsg: err.Error()})
 		return
 	}
-	if req.Screenshot.IntervalMinutes < 0 {
+	screenshotIntervalMinutes := GetCurrentConfig().Screenshot.IntervalMinutes
+	if req.Screenshot != nil {
+		screenshotIntervalMinutes = req.Screenshot.IntervalMinutes
+	}
+	if screenshotIntervalMinutes < 0 {
 		JSONResponse(w, http.StatusBadRequest, APIResponse{OK: false, ErrMsg: "screenshot.interval_minutes не может быть отрицательным"})
 		return
 	}
@@ -706,7 +719,7 @@ func HandleConfigurationUpdate(w http.ResponseWriter, r *http.Request) {
 		ScheduleConfig{Playlist: normalizedPlaylist, Video: normalizedVideo, Rest: restConfigPairs},
 		AudioConfig{Output: req.Audio.Output},
 		ScreenshotConfig{
-			IntervalMinutes: req.Screenshot.IntervalMinutes,
+			IntervalMinutes: screenshotIntervalMinutes,
 			PathTemplate:    GetCurrentConfig().Screenshot.PathTemplate,
 			Input:           GetCurrentConfig().Screenshot.Input,
 		},

--- a/internal/agent/menu.go
+++ b/internal/agent/menu.go
@@ -201,11 +201,17 @@ type AudioSettings struct {
 	Output string `json:"output"`
 }
 
+// ScreenshotSettings describes periodic screenshot capture settings.
+type ScreenshotSettings struct {
+	IntervalMinutes int `json:"interval_minutes"`
+}
+
 // ConfigurationSettings aggregates playlist upload configuration, schedule and audio output.
 type ConfigurationSettings struct {
-	Playlist PlaylistUploadConfig `json:"playlist"`
-	Schedule ScheduleSettings     `json:"schedule"`
-	Audio    AudioSettings        `json:"audio"`
+	Playlist   PlaylistUploadConfig `json:"playlist"`
+	Schedule   ScheduleSettings     `json:"schedule"`
+	Audio      AudioSettings        `json:"audio"`
+	Screenshot ScreenshotSettings   `json:"screenshot"`
 }
 
 // ServiceStatusResponse describes the service status returned by the
@@ -594,6 +600,9 @@ func HandleConfigurationGet(w http.ResponseWriter, r *http.Request) {
 		Audio: AudioSettings{
 			Output: cfg.Audio.Output,
 		},
+		Screenshot: ScreenshotSettings{
+			IntervalMinutes: cfg.Screenshot.IntervalMinutes,
+		},
 	}})
 }
 
@@ -638,6 +647,10 @@ func HandleConfigurationUpdate(w http.ResponseWriter, r *http.Request) {
 
 	if err := validateAudioOutput(req.Audio.Output); err != nil {
 		JSONResponse(w, http.StatusBadRequest, APIResponse{OK: false, ErrMsg: err.Error()})
+		return
+	}
+	if req.Screenshot.IntervalMinutes < 0 {
+		JSONResponse(w, http.StatusBadRequest, APIResponse{OK: false, ErrMsg: "screenshot.interval_minutes не может быть отрицательным"})
 		return
 	}
 
@@ -692,6 +705,10 @@ func HandleConfigurationUpdate(w http.ResponseWriter, r *http.Request) {
 		PlaylistConfig{Source: playlistSource, Destination: playlistDestination},
 		ScheduleConfig{Playlist: normalizedPlaylist, Video: normalizedVideo, Rest: restConfigPairs},
 		AudioConfig{Output: req.Audio.Output},
+		ScreenshotConfig{
+			IntervalMinutes: req.Screenshot.IntervalMinutes,
+			PathTemplate:    GetCurrentConfig().Screenshot.PathTemplate,
+		},
 	); err != nil {
 		log.Printf("Warning: Failed to update config file: %v", err)
 	}

--- a/internal/agent/menu.go
+++ b/internal/agent/menu.go
@@ -708,6 +708,7 @@ func HandleConfigurationUpdate(w http.ResponseWriter, r *http.Request) {
 		ScreenshotConfig{
 			IntervalMinutes: req.Screenshot.IntervalMinutes,
 			PathTemplate:    GetCurrentConfig().Screenshot.PathTemplate,
+			Input:           GetCurrentConfig().Screenshot.Input,
 		},
 	); err != nil {
 		log.Printf("Warning: Failed to update config file: %v", err)

--- a/internal/agent/menu.go
+++ b/internal/agent/menu.go
@@ -206,7 +206,7 @@ type ScreenshotSettings struct {
 	IntervalMinutes int `json:"interval_minutes"`
 }
 
-// ConfigurationSettings aggregates playlist upload configuration, schedule and audio output.
+// ConfigurationSettings aggregates playlist upload configuration, schedule, audio output, and screenshot capture settings.
 type ConfigurationSettings struct {
 	Playlist   PlaylistUploadConfig `json:"playlist"`
 	Schedule   ScheduleSettings     `json:"schedule"`

--- a/internal/agent/menu_test.go
+++ b/internal/agent/menu_test.go
@@ -308,6 +308,10 @@ func TestHandleConfigurationGet(t *testing.T) {
 		Audio: AudioConfig{
 			Output: "hdmi",
 		},
+		Screenshot: ScreenshotConfig{
+			IntervalMinutes: 30,
+			PathTemplate:    "/home/pi/Pictures/cam_$(date +%F_%H-%M-%S).jpg",
+		},
 	}
 
 	// Save and restore original config
@@ -361,6 +365,9 @@ func TestHandleConfigurationGet(t *testing.T) {
 
 	if resp.Data.Audio.Output != "hdmi" {
 		t.Fatalf("expected hdmi output, got %s", resp.Data.Audio.Output)
+	}
+	if resp.Data.Screenshot.IntervalMinutes != 30 {
+		t.Fatalf("expected screenshot interval 30, got %d", resp.Data.Screenshot.IntervalMinutes)
 	}
 }
 
@@ -416,7 +423,7 @@ WantedBy = multi-user.target
 		CrontabWriteFunc = originalWrite
 	})
 
-	body := `{"playlist":{"source":"/mnt/ya.disk/playlist/test/","destination":"/mnt/usb/playlist/"},"schedule":{"playlist":["6:05","16:28"],"video":["22:22"],"rest":[{"start":"12:00","stop":"13:00"},{"start":"23:45","stop":"07:00"}]},"audio":{"output":"jack"}}`
+	body := `{"playlist":{"source":"/mnt/ya.disk/playlist/test/","destination":"/mnt/usb/playlist/"},"schedule":{"playlist":["6:05","16:28"],"video":["22:22"],"rest":[{"start":"12:00","stop":"13:00"},{"start":"23:45","stop":"07:00"}]},"audio":{"output":"jack"},"screenshot":{"interval_minutes":20}}`
 	req := httptest.NewRequest(http.MethodPut, "/api/menu/configuration/update", strings.NewReader(body))
 	req.Header.Set("Authorization", "Bearer test-key")
 	w := httptest.NewRecorder()
@@ -466,6 +473,7 @@ WantedBy = multi-user.target
 	if !strings.Contains(string(audioData), "card 1") {
 		t.Fatalf("expected jack config, got %s", string(audioData))
 	}
+
 }
 
 func TestWriteTimerScheduleProducesValidUnit(t *testing.T) {
@@ -526,6 +534,42 @@ func TestHandleConfigurationUploadValidation(t *testing.T) {
 	}
 }
 
+func TestHandleConfigurationUploadValidationRejectsNegativeScreenshotInterval(t *testing.T) {
+	ServerKey = "test-key"
+
+	tmp := t.TempDir()
+	servicePath := filepath.Join(tmp, "playlist.upload.service")
+	originalService := PlaylistServicePath
+	originalPlaylist := PlaylistTimerPath
+	originalVideo := VideoTimerPath
+	originalAudio := AudioConfigPath
+	PlaylistServicePath = servicePath
+	PlaylistTimerPath = filepath.Join(tmp, "playlist.upload.timer")
+	VideoTimerPath = filepath.Join(tmp, "video.upload.timer")
+	AudioConfigPath = filepath.Join(tmp, "asound.conf")
+	t.Cleanup(func() {
+		PlaylistServicePath = originalService
+		PlaylistTimerPath = originalPlaylist
+		VideoTimerPath = originalVideo
+		AudioConfigPath = originalAudio
+	})
+
+	if err := os.WriteFile(servicePath, []byte("[Service]\nExecStart = /usr/bin/rsync /a /b"), 0644); err != nil {
+		t.Fatalf("failed to seed service file: %v", err)
+	}
+
+	body := `{"playlist":{"source":"","destination":"/mnt/usb"},"schedule":{"playlist":["08:00"],"video":["08:00"],"rest":[]},"audio":{"output":"hdmi"},"screenshot":{"interval_minutes":-1}}`
+	req := httptest.NewRequest(http.MethodPut, "/api/menu/configuration/update", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-key")
+	w := httptest.NewRecorder()
+
+	HandleConfigurationUpdate(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
 func TestHandleConfigurationUpdateEmptySourceUsesDefault(t *testing.T) {
 	ServerKey = "test-key"
 
@@ -574,7 +618,7 @@ func TestHandleConfigurationUpdateEmptySourceUsesDefault(t *testing.T) {
 	})
 
 	// Test with empty source - should use default
-	body := `{"playlist":{"source":"","destination":"/mnt/usb/test/"},"schedule":{"playlist":["08:00"],"video":["12:00"],"rest":[]},"audio":{"output":"hdmi"}}`
+	body := `{"playlist":{"source":"","destination":"/mnt/usb/test/"},"schedule":{"playlist":["08:00"],"video":["12:00"],"rest":[]},"audio":{"output":"hdmi"},"screenshot":{"interval_minutes":15}}`
 	req := httptest.NewRequest(http.MethodPut, "/api/menu/configuration/update", strings.NewReader(body))
 	req.Header.Set("Authorization", "Bearer test-key")
 	w := httptest.NewRecorder()
@@ -593,6 +637,10 @@ func TestHandleConfigurationUpdateEmptySourceUsesDefault(t *testing.T) {
 
 	if !strings.Contains(string(updatedService), "media-pi.core server /mnt/usb/test/") {
 		t.Errorf("expected default source 'media-pi.core server' in service file, got: %s", string(updatedService))
+	}
+
+	if cfg := GetCurrentConfig(); cfg.Screenshot.IntervalMinutes != 15 {
+		t.Errorf("expected screenshot interval 15 in config, got %d", cfg.Screenshot.IntervalMinutes)
 	}
 }
 

--- a/internal/agent/menu_test.go
+++ b/internal/agent/menu_test.go
@@ -644,6 +644,70 @@ func TestHandleConfigurationUpdateEmptySourceUsesDefault(t *testing.T) {
 	}
 }
 
+func TestHandleConfigurationUpdatePreservesScreenshotIntervalWhenOmitted(t *testing.T) {
+	ServerKey = "test-key"
+
+	tmp := t.TempDir()
+	servicePath := filepath.Join(tmp, "playlist.upload.service")
+	originalService := PlaylistServicePath
+	originalPlaylist := PlaylistTimerPath
+	originalVideo := VideoTimerPath
+	originalAudio := AudioConfigPath
+	originalCfgPath := ConfigPath
+	PlaylistServicePath = servicePath
+	PlaylistTimerPath = filepath.Join(tmp, "playlist.upload.timer")
+	VideoTimerPath = filepath.Join(tmp, "video.upload.timer")
+	AudioConfigPath = filepath.Join(tmp, "asound.conf")
+	ConfigPath = filepath.Join(tmp, "agent.yaml")
+	t.Cleanup(func() {
+		PlaylistServicePath = originalService
+		PlaylistTimerPath = originalPlaylist
+		VideoTimerPath = originalVideo
+		AudioConfigPath = originalAudio
+		ConfigPath = originalCfgPath
+	})
+
+	if err := os.WriteFile(servicePath, []byte("[Service]\nExecStart = /usr/bin/rsync /old/src /old/dst"), 0644); err != nil {
+		t.Fatalf("failed to seed service file: %v", err)
+	}
+
+	config := Config{
+		ServerKey:  "test-key",
+		ListenAddr: "0.0.0.0:8081",
+		Playlist:   PlaylistConfig{Source: "media-pi.core server", Destination: "/mnt/usb"},
+		Schedule:   ScheduleConfig{Playlist: []string{"08:00"}, Video: []string{"12:00"}},
+		Audio:      AudioConfig{Output: "hdmi"},
+		Screenshot: ScreenshotConfig{IntervalMinutes: 15, PathTemplate: "/tmp/cam.jpg", Input: "/dev/video0"},
+	}
+	configMutex.Lock()
+	currentConfig = &config
+	configMutex.Unlock()
+
+	originalRead := CrontabReadFunc
+	originalWrite := CrontabWriteFunc
+	CrontabReadFunc = func() (string, error) { return "", nil }
+	CrontabWriteFunc = func(string) error { return nil }
+	t.Cleanup(func() {
+		CrontabReadFunc = originalRead
+		CrontabWriteFunc = originalWrite
+	})
+
+	body := `{"playlist":{"source":"media-pi.core server","destination":"/mnt/usb/test/"},"schedule":{"playlist":["09:00"],"video":["13:00"],"rest":[]},"audio":{"output":"jack"}}`
+	req := httptest.NewRequest(http.MethodPut, "/api/menu/configuration/update", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-key")
+	w := httptest.NewRecorder()
+
+	HandleConfigurationUpdate(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if cfg := GetCurrentConfig(); cfg.Screenshot.IntervalMinutes != 15 {
+		t.Fatalf("expected screenshot interval to remain 15, got %d", cfg.Screenshot.IntervalMinutes)
+	}
+}
+
 func TestHandleSystemReloadMethodNotAllowed(t *testing.T) {
 	ServerKey = "test-key"
 

--- a/internal/agent/sync.go
+++ b/internal/agent/sync.go
@@ -746,6 +746,9 @@ func schedulerLoop() {
 
 func captureScreenshot() error {
 	cfg := GetCurrentConfig()
+	if cfg.Screenshot.IntervalMinutes <= 0 {
+		return nil
+	}
 	pathTemplate := strings.TrimSpace(cfg.Screenshot.PathTemplate)
 	if pathTemplate == "" {
 		return fmt.Errorf("screenshot path template not configured")

--- a/internal/agent/sync.go
+++ b/internal/agent/sync.go
@@ -25,13 +25,14 @@ import (
 var (
 	syncStatusFilePath   = "/var/media-pi/sync/sync-status.json"
 	runScreenshotCapture = captureScreenshot
-	runScreenshotCommand = func(pathTemplate string) error {
-		cmd := exec.Command("/bin/bash", "-c", fmt.Sprintf(`/usr/bin/ffmpeg -loglevel error -y -frames:v 1 "%s"`, pathTemplate))
+	runScreenshotCommand = func(outputPath string) error {
+		cmd := exec.Command("/usr/bin/ffmpeg", "-loglevel", "error", "-y", "-frames:v", "1", outputPath)
 		if out, err := cmd.CombinedOutput(); err != nil {
 			return fmt.Errorf("ffmpeg command failed: %w: %s", err, strings.TrimSpace(string(out)))
 		}
 		return nil
 	}
+	screenshotNow = time.Now
 )
 
 // ManifestItem represents a single file in the sync manifest.
@@ -753,7 +754,12 @@ func captureScreenshot() error {
 	if pathTemplate == "" {
 		return fmt.Errorf("screenshot path template not configured")
 	}
-	return runScreenshotCommand(pathTemplate)
+	return runScreenshotCommand(renderScreenshotOutputPath(pathTemplate, screenshotNow()))
+}
+
+func renderScreenshotOutputPath(pathTemplate string, now time.Time) string {
+	const dateToken = "$(date +%F_%H-%M-%S)"
+	return strings.ReplaceAll(pathTemplate, dateToken, now.Format("2006-01-02_15-04-05"))
 }
 
 // SetScheduledSyncCallback sets the callback to be called after successful scheduled syncs.

--- a/internal/agent/sync.go
+++ b/internal/agent/sync.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -22,7 +23,15 @@ import (
 )
 
 var (
-	syncStatusFilePath = "/var/media-pi/sync/sync-status.json"
+	syncStatusFilePath   = "/var/media-pi/sync/sync-status.json"
+	runScreenshotCapture = captureScreenshot
+	runScreenshotCommand = func(pathTemplate string) error {
+		cmd := exec.Command("/bin/bash", "-c", fmt.Sprintf(`/usr/bin/ffmpeg -loglevel error -y -frames:v 1 "%s"`, pathTemplate))
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("ffmpeg command failed: %w: %s", err, strings.TrimSpace(string(out)))
+		}
+		return nil
+	}
 )
 
 // ManifestItem represents a single file in the sync manifest.
@@ -709,6 +718,21 @@ func schedulerLoop() {
 			}
 		}
 
+		// Add periodic screenshot capture task.
+		if config.Screenshot.IntervalMinutes > 0 {
+			cronSpec := fmt.Sprintf("@every %dm", config.Screenshot.IntervalMinutes)
+			cronSchedulerLock.Lock()
+			_, err := cronScheduler.AddFunc(cronSpec, func() {
+				if err := runScreenshotCapture(); err != nil {
+					log.Printf("Failed to capture screenshot: %v", err)
+				}
+			})
+			cronSchedulerLock.Unlock()
+			if err != nil {
+				log.Printf("Warning: Failed to schedule screenshot capture every %d minutes: %v", config.Screenshot.IntervalMinutes, err)
+			}
+		}
+
 		// Start scheduler with lock protection
 		cronSchedulerLock.Lock()
 		cronScheduler.Start()
@@ -718,6 +742,15 @@ func schedulerLoop() {
 		<-syncReloadChan
 		log.Println("Reloading sync schedule")
 	}
+}
+
+func captureScreenshot() error {
+	cfg := GetCurrentConfig()
+	pathTemplate := strings.TrimSpace(cfg.Screenshot.PathTemplate)
+	if pathTemplate == "" {
+		return fmt.Errorf("screenshot path template not configured")
+	}
+	return runScreenshotCommand(pathTemplate)
 }
 
 // SetScheduledSyncCallback sets the callback to be called after successful scheduled syncs.

--- a/internal/agent/sync.go
+++ b/internal/agent/sync.go
@@ -25,8 +25,8 @@ import (
 var (
 	syncStatusFilePath   = "/var/media-pi/sync/sync-status.json"
 	runScreenshotCapture = captureScreenshot
-	runScreenshotCommand = func(outputPath string) error {
-		cmd := exec.Command("/usr/bin/ffmpeg", "-loglevel", "error", "-y", "-frames:v", "1", outputPath)
+	runScreenshotCommand = func(inputPath, outputPath string) error {
+		cmd := exec.Command("/usr/bin/ffmpeg", "-loglevel", "error", "-y", "-i", inputPath, "-frames:v", "1", outputPath)
 		if out, err := cmd.CombinedOutput(); err != nil {
 			return fmt.Errorf("ffmpeg command failed: %w: %s", err, strings.TrimSpace(string(out)))
 		}
@@ -754,7 +754,11 @@ func captureScreenshot() error {
 	if pathTemplate == "" {
 		return fmt.Errorf("screenshot path template not configured")
 	}
-	return runScreenshotCommand(renderScreenshotOutputPath(pathTemplate, screenshotNow()))
+	input := strings.TrimSpace(cfg.Screenshot.Input)
+	if input == "" {
+		return fmt.Errorf("screenshot input is not configured")
+	}
+	return runScreenshotCommand(input, renderScreenshotOutputPath(pathTemplate, screenshotNow()))
 }
 
 func renderScreenshotOutputPath(pathTemplate string, now time.Time) string {

--- a/internal/agent/sync_test.go
+++ b/internal/agent/sync_test.go
@@ -829,7 +829,8 @@ func TestCaptureScreenshotUsesConfiguredTemplate(t *testing.T) {
 	currentConfig = &Config{
 		Screenshot: ScreenshotConfig{
 			IntervalMinutes: 30,
-			PathTemplate: "/home/pi/Pictures/cam_$(date +%F_%H-%M-%S).jpg",
+			PathTemplate:    "/home/pi/Pictures/cam_$(date +%F_%H-%M-%S).jpg",
+			Input:           "/dev/video0",
 		},
 	}
 	configMutex.Unlock()
@@ -842,9 +843,11 @@ func TestCaptureScreenshotUsesConfiguredTemplate(t *testing.T) {
 	originalRunner := runScreenshotCommand
 	originalNow := screenshotNow
 	called := false
+	var gotInput string
 	var gotPath string
-	runScreenshotCommand = func(outputPath string) error {
+	runScreenshotCommand = func(inputPath, outputPath string) error {
 		called = true
+		gotInput = inputPath
 		gotPath = outputPath
 		return nil
 	}
@@ -862,6 +865,9 @@ func TestCaptureScreenshotUsesConfiguredTemplate(t *testing.T) {
 	if !called {
 		t.Fatalf("expected screenshot command runner to be called")
 	}
+	if gotInput != "/dev/video0" {
+		t.Fatalf("unexpected input path: %q", gotInput)
+	}
 	if gotPath != "/home/pi/Pictures/cam_2026-04-22_09-31-47.jpg" {
 		t.Fatalf("unexpected output path: %q", gotPath)
 	}
@@ -874,6 +880,7 @@ func TestCaptureScreenshotRequiresTemplate(t *testing.T) {
 		Screenshot: ScreenshotConfig{
 			IntervalMinutes: 30,
 			PathTemplate:    "   ",
+			Input:           "/dev/video0",
 		},
 	}
 	configMutex.Unlock()
@@ -895,6 +902,7 @@ func TestCaptureScreenshotDisabledWhenIntervalIsZero(t *testing.T) {
 		Screenshot: ScreenshotConfig{
 			IntervalMinutes: 0,
 			PathTemplate:    "/home/pi/Pictures/cam_$(date +%F_%H-%M-%S).jpg",
+			Input:           "/dev/video0",
 		},
 	}
 	configMutex.Unlock()
@@ -906,7 +914,7 @@ func TestCaptureScreenshotDisabledWhenIntervalIsZero(t *testing.T) {
 
 	originalRunner := runScreenshotCommand
 	called := false
-	runScreenshotCommand = func(outputPath string) error {
+	runScreenshotCommand = func(inputPath, outputPath string) error {
 		called = true
 		return nil
 	}
@@ -919,6 +927,28 @@ func TestCaptureScreenshotDisabledWhenIntervalIsZero(t *testing.T) {
 	}
 	if called {
 		t.Fatalf("expected screenshot command runner to not be called when interval is zero")
+	}
+}
+
+func TestCaptureScreenshotRequiresInput(t *testing.T) {
+	configMutex.Lock()
+	originalConfig := currentConfig
+	currentConfig = &Config{
+		Screenshot: ScreenshotConfig{
+			IntervalMinutes: 30,
+			PathTemplate:    "/home/pi/Pictures/cam_$(date +%F_%H-%M-%S).jpg",
+			Input:           "   ",
+		},
+	}
+	configMutex.Unlock()
+	t.Cleanup(func() {
+		configMutex.Lock()
+		currentConfig = originalConfig
+		configMutex.Unlock()
+	})
+
+	if err := captureScreenshot(); err == nil {
+		t.Fatalf("expected error when screenshot input is empty")
 	}
 }
 

--- a/internal/agent/sync_test.go
+++ b/internal/agent/sync_test.go
@@ -828,6 +828,7 @@ func TestCaptureScreenshotUsesConfiguredTemplate(t *testing.T) {
 	originalConfig := currentConfig
 	currentConfig = &Config{
 		Screenshot: ScreenshotConfig{
+			IntervalMinutes: 30,
 			PathTemplate: "/home/pi/Pictures/cam_$(date +%F_%H-%M-%S).jpg",
 		},
 	}
@@ -866,7 +867,8 @@ func TestCaptureScreenshotRequiresTemplate(t *testing.T) {
 	originalConfig := currentConfig
 	currentConfig = &Config{
 		Screenshot: ScreenshotConfig{
-			PathTemplate: "   ",
+			IntervalMinutes: 30,
+			PathTemplate:    "   ",
 		},
 	}
 	configMutex.Unlock()
@@ -878,5 +880,39 @@ func TestCaptureScreenshotRequiresTemplate(t *testing.T) {
 
 	if err := captureScreenshot(); err == nil {
 		t.Fatalf("expected error when screenshot template is empty")
+	}
+}
+
+func TestCaptureScreenshotDisabledWhenIntervalIsZero(t *testing.T) {
+	configMutex.Lock()
+	originalConfig := currentConfig
+	currentConfig = &Config{
+		Screenshot: ScreenshotConfig{
+			IntervalMinutes: 0,
+			PathTemplate:    "/home/pi/Pictures/cam_$(date +%F_%H-%M-%S).jpg",
+		},
+	}
+	configMutex.Unlock()
+	t.Cleanup(func() {
+		configMutex.Lock()
+		currentConfig = originalConfig
+		configMutex.Unlock()
+	})
+
+	originalRunner := runScreenshotCommand
+	called := false
+	runScreenshotCommand = func(pathTemplate string) error {
+		called = true
+		return nil
+	}
+	t.Cleanup(func() {
+		runScreenshotCommand = originalRunner
+	})
+
+	if err := captureScreenshot(); err != nil {
+		t.Fatalf("captureScreenshot() returned error: %v", err)
+	}
+	if called {
+		t.Fatalf("expected screenshot command runner to not be called when interval is zero")
 	}
 }

--- a/internal/agent/sync_test.go
+++ b/internal/agent/sync_test.go
@@ -822,3 +822,61 @@ func TestContextCancellation(t *testing.T) {
 		t.Errorf("syncFiles() should return context.Canceled, got: %v", err)
 	}
 }
+
+func TestCaptureScreenshotUsesConfiguredTemplate(t *testing.T) {
+	configMutex.Lock()
+	originalConfig := currentConfig
+	currentConfig = &Config{
+		Screenshot: ScreenshotConfig{
+			PathTemplate: "/home/pi/Pictures/cam_$(date +%F_%H-%M-%S).jpg",
+		},
+	}
+	configMutex.Unlock()
+	t.Cleanup(func() {
+		configMutex.Lock()
+		currentConfig = originalConfig
+		configMutex.Unlock()
+	})
+
+	originalRunner := runScreenshotCommand
+	called := false
+	var gotTemplate string
+	runScreenshotCommand = func(pathTemplate string) error {
+		called = true
+		gotTemplate = pathTemplate
+		return nil
+	}
+	t.Cleanup(func() {
+		runScreenshotCommand = originalRunner
+	})
+
+	if err := captureScreenshot(); err != nil {
+		t.Fatalf("captureScreenshot() returned error: %v", err)
+	}
+	if !called {
+		t.Fatalf("expected screenshot command runner to be called")
+	}
+	if gotTemplate != "/home/pi/Pictures/cam_$(date +%F_%H-%M-%S).jpg" {
+		t.Fatalf("unexpected template: %q", gotTemplate)
+	}
+}
+
+func TestCaptureScreenshotRequiresTemplate(t *testing.T) {
+	configMutex.Lock()
+	originalConfig := currentConfig
+	currentConfig = &Config{
+		Screenshot: ScreenshotConfig{
+			PathTemplate: "   ",
+		},
+	}
+	configMutex.Unlock()
+	t.Cleanup(func() {
+		configMutex.Lock()
+		currentConfig = originalConfig
+		configMutex.Unlock()
+	})
+
+	if err := captureScreenshot(); err == nil {
+		t.Fatalf("expected error when screenshot template is empty")
+	}
+}

--- a/internal/agent/sync_test.go
+++ b/internal/agent/sync_test.go
@@ -840,15 +840,20 @@ func TestCaptureScreenshotUsesConfiguredTemplate(t *testing.T) {
 	})
 
 	originalRunner := runScreenshotCommand
+	originalNow := screenshotNow
 	called := false
-	var gotTemplate string
-	runScreenshotCommand = func(pathTemplate string) error {
+	var gotPath string
+	runScreenshotCommand = func(outputPath string) error {
 		called = true
-		gotTemplate = pathTemplate
+		gotPath = outputPath
 		return nil
+	}
+	screenshotNow = func() time.Time {
+		return time.Date(2026, time.April, 22, 9, 31, 47, 0, time.UTC)
 	}
 	t.Cleanup(func() {
 		runScreenshotCommand = originalRunner
+		screenshotNow = originalNow
 	})
 
 	if err := captureScreenshot(); err != nil {
@@ -857,8 +862,8 @@ func TestCaptureScreenshotUsesConfiguredTemplate(t *testing.T) {
 	if !called {
 		t.Fatalf("expected screenshot command runner to be called")
 	}
-	if gotTemplate != "/home/pi/Pictures/cam_$(date +%F_%H-%M-%S).jpg" {
-		t.Fatalf("unexpected template: %q", gotTemplate)
+	if gotPath != "/home/pi/Pictures/cam_2026-04-22_09-31-47.jpg" {
+		t.Fatalf("unexpected output path: %q", gotPath)
 	}
 }
 
@@ -901,7 +906,7 @@ func TestCaptureScreenshotDisabledWhenIntervalIsZero(t *testing.T) {
 
 	originalRunner := runScreenshotCommand
 	called := false
-	runScreenshotCommand = func(pathTemplate string) error {
+	runScreenshotCommand = func(outputPath string) error {
 		called = true
 		return nil
 	}
@@ -914,5 +919,18 @@ func TestCaptureScreenshotDisabledWhenIntervalIsZero(t *testing.T) {
 	}
 	if called {
 		t.Fatalf("expected screenshot command runner to not be called when interval is zero")
+	}
+}
+
+func TestRenderScreenshotOutputPath(t *testing.T) {
+	now := time.Date(2026, time.April, 22, 9, 31, 47, 0, time.UTC)
+	got := renderScreenshotOutputPath("/home/pi/Pictures/cam_$(date +%F_%H-%M-%S).jpg", now)
+	if got != "/home/pi/Pictures/cam_2026-04-22_09-31-47.jpg" {
+		t.Fatalf("unexpected rendered path: %q", got)
+	}
+
+	plain := renderScreenshotOutputPath("/home/pi/Pictures/cam.jpg", now)
+	if plain != "/home/pi/Pictures/cam.jpg" {
+		t.Fatalf("path without token should be unchanged, got: %q", plain)
 	}
 }

--- a/packaging/agent.yaml
+++ b/packaging/agent.yaml
@@ -29,4 +29,5 @@ playlist:
 # Screenshot configuration
 screenshot:
   interval_minutes: 0
+  input: "/dev/video0"
   path_template: "/home/pi/Pictures/cam_$(date +%F_%H-%M-%S).jpg"

--- a/packaging/agent.yaml
+++ b/packaging/agent.yaml
@@ -25,3 +25,8 @@ max_parallel_downloads: 3
 # Playlist configuration
 playlist:
   destination: "/var/media-pi"
+
+# Screenshot configuration
+screenshot:
+  interval_minutes: 0
+  path_template: "/home/pi/Pictures/cam_$(date +%F_%H-%M-%S).jpg"


### PR DESCRIPTION
### Motivation
- Extend the `/api/menu/configuration/get` and `/api/menu/configuration/update` payloads to carry a screenshot configuration DTO so the UI / API can enable/disable periodic captures.
- Execute periodic screenshot captures using the platform `ffmpeg` binary with a statically-configured file name template stored in the agent YAML.
- Persist screenshot settings alongside playlist, schedule and audio in the YAML-backed agent configuration so scheduler and other components can read them.

### Description
- Added `ScreenshotConfig` to `Config` and `ScreenshotSettings` to the API DTO, and included `screenshot.interval_minutes`/`path_template` in YAML defaults and `packaging/agent.yaml` (default `path_template` is `/home/pi/Pictures/cam_$(date +%F_%H-%M-%S).jpg`).
- Extended `ConfigurationSettings` (API) and `HandleConfigurationGet`/`HandleConfigurationUpdate` to return/accept `screenshot.interval_minutes` and validate it (`interval_minutes >= 0`).
- Updated `UpdateConfigSettings` signature to accept `ScreenshotConfig` and persist screenshot settings to the YAML config file via `saveConfigToFile`.
- Scheduler now adds an `@every <N>m` job when `Screenshot.IntervalMinutes > 0` which runs a screenshot capture implemented by `captureScreenshot` that invokes `/bin/bash -c '/usr/bin/ffmpeg -loglevel error -y -frames:v 1 "<path_template>"'`; the command runner is test-injectable via `runScreenshotCommand`.
- Added unit tests covering: GET includes screenshot settings, UPDATE persists `interval_minutes`, validation rejects negative intervals, `UpdateConfigSettings` saves screenshot settings, and `captureScreenshot` behavior with configured / missing templates.

### Testing
- Ran unit tests: `go test ./...` and `go test ./internal/agent -coverprofile=/tmp/agent.cover.out -covermode=atomic`; all tests passed.
- Ran static checks: `go vet ./...` with no reported issues.
- Reported package coverage for `internal/agent` was `57.6%` of statements (tests for screenshot functionality were added and passed, overall coverage remains below the 95% target for this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e87218077883219db784cfce491301)