### PR TITLE
fix:  add workflow permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ name: Lint
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: '${{ github.workflow }}-${{ github.job }}-${{ github.head_ref || github.ref_name }}'
   cancel-in-progress: true    


### PR DESCRIPTION
Potential fix for [https://github.com/sw-consulting/media-pi.device/security/code-scanning/1](https://github.com/sw-consulting/media-pi.device/security/code-scanning/1)

Add an explicit top-level `permissions` block to `.github/workflows/lint.yml` so all jobs inherit least-privilege token access. The best minimal fix is:

- `permissions:`
  - `contents: read`

This supports `actions/checkout` and typical linting actions while preventing unintended write scopes. Place it at workflow root level (for example after `on:` and before `concurrency:`), so both `shellcheck` and `golangci-lint` jobs are covered without duplicating config.

No imports, methods, or dependencies are needed; this is a YAML workflow configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
