### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@
 
 name: Build & Package Media Pi Agent
 
+permissions:
+  contents: read
+
 concurrency:
   group: '${{ github.workflow }}-${{ github.job }}-${{ github.head_ref || github.ref_name }}'
   cancel-in-progress: true    


### PR DESCRIPTION
Potential fix for [https://github.com/sw-consulting/media-pi.device/security/code-scanning/3](https://github.com/sw-consulting/media-pi.device/security/code-scanning/3)

Add an explicit root-level `permissions` block in `.github/workflows/build.yml` so all jobs default to least privilege. The best minimal fix is:

- At workflow top level (after `name`), add:
  - `permissions:`
  - `  contents: read`

This preserves behavior for build/test/package/integration jobs while documenting and enforcing least privilege. The existing `release` job-level `permissions: contents: write` should remain unchanged; job-level permissions override root defaults, so release publishing still works.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
