### PR TITLE
fix: address uncontrolled data in path expression

### DIFF
--- a/internal/agent/config_dualwrite_test.go
+++ b/internal/agent/config_dualwrite_test.go
@@ -132,7 +132,7 @@ WantedBy = multi-user.target
 	if err != nil {
 		t.Fatalf("failed to read service file: %v", err)
 	}
-	if !strings.Contains(string(serviceData), "/new/src/") || !strings.Contains(string(serviceData), "/new/dst/") {
+	if !strings.Contains(string(serviceData), "/new/src/") || !strings.Contains(string(serviceData), "/new/dst") {
 		t.Errorf("service file not updated correctly: %s", string(serviceData))
 	}
 
@@ -167,7 +167,7 @@ WantedBy = multi-user.target
 	if cfg.Playlist.Source != "/new/src/" {
 		t.Errorf("config source not updated: %s", cfg.Playlist.Source)
 	}
-	if cfg.Playlist.Destination != "/new/dst/" {
+	if cfg.Playlist.Destination != "/new/dst" {
 		t.Errorf("config destination not updated: %s", cfg.Playlist.Destination)
 	}
 	if len(cfg.Schedule.Playlist) != 2 || cfg.Schedule.Playlist[0] != "11:30" {

--- a/internal/agent/menu.go
+++ b/internal/agent/menu.go
@@ -703,9 +703,18 @@ func HandleConfigurationUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	cleanDestination := filepath.Clean(playlistDestination)
-	if !filepath.IsAbs(cleanDestination) || strings.Contains(cleanDestination, "..") {
+	if !filepath.IsAbs(cleanDestination) {
 		JSONResponse(w, http.StatusBadRequest, APIResponse{OK: false, ErrMsg: "Недопустимый путь destination"})
 		return
+	}
+	// Check each component of the original path for ".." traversal tokens.
+	// Checking components (not a substring) avoids false negatives after Clean resolves
+	// traversal (e.g. /a/../b → /b) and false positives on names like "..." or "..cache".
+	for _, component := range strings.Split(filepath.ToSlash(playlistDestination), "/") {
+		if component == ".." {
+			JSONResponse(w, http.StatusBadRequest, APIResponse{OK: false, ErrMsg: "Недопустимый путь destination"})
+			return
+		}
 	}
 
 	if hasInvalidTimes(req.Schedule.Playlist, req.Schedule.Video) {
@@ -752,7 +761,7 @@ func HandleConfigurationUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := writePlaylistUploadConfig(PlaylistServicePath, playlistSource, playlistDestination); err != nil {
+	if err := writePlaylistUploadConfig(PlaylistServicePath, playlistSource, cleanDestination); err != nil {
 		JSONResponse(w, http.StatusInternalServerError, APIResponse{OK: false, ErrMsg: fmt.Sprintf("Не удалось обновить конфигурацию: %v", err)})
 		return
 	}

--- a/internal/agent/menu.go
+++ b/internal/agent/menu.go
@@ -702,6 +702,11 @@ func HandleConfigurationUpdate(w http.ResponseWriter, r *http.Request) {
 		JSONResponse(w, http.StatusBadRequest, APIResponse{OK: false, ErrMsg: "Поле destination обязательно"})
 		return
 	}
+	cleanDestination := filepath.Clean(playlistDestination)
+	if !filepath.IsAbs(cleanDestination) || strings.Contains(cleanDestination, "..") {
+		JSONResponse(w, http.StatusBadRequest, APIResponse{OK: false, ErrMsg: "Недопустимый путь destination"})
+		return
+	}
 
 	if hasInvalidTimes(req.Schedule.Playlist, req.Schedule.Video) {
 		JSONResponse(w, http.StatusBadRequest, APIResponse{OK: false, ErrMsg: "Неверный формат времени. Используйте HH:MM"})
@@ -780,7 +785,7 @@ func HandleConfigurationUpdate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := UpdateConfigSettings(
-		PlaylistConfig{Source: playlistSource, Destination: playlistDestination},
+		PlaylistConfig{Source: playlistSource, Destination: cleanDestination},
 		ScheduleConfig{Playlist: normalizedPlaylist, Video: normalizedVideo, Rest: restConfigPairs},
 		AudioConfig{Output: req.Audio.Output},
 		ScreenshotConfig{

--- a/internal/agent/menu_test.go
+++ b/internal/agent/menu_test.go
@@ -859,12 +859,13 @@ func TestHandleConfigurationUpdateDestinationValidation(t *testing.T) {
 		name        string
 		destination string
 		wantCode    int
+		wantErrMsg  string
 	}{
 		// Rejection cases
-		{name: "relative path", destination: "relative/path", wantCode: http.StatusBadRequest},
-		{name: "dot-dot component mid-path", destination: "/mnt/usb/../etc", wantCode: http.StatusBadRequest},
-		{name: "dot-dot component at start", destination: "/../etc/passwd", wantCode: http.StatusBadRequest},
-		{name: "only dot-dot", destination: "/mnt/../../etc", wantCode: http.StatusBadRequest},
+		{name: "relative path", destination: "relative/path", wantCode: http.StatusBadRequest, wantErrMsg: "Недопустимый путь destination"},
+		{name: "dot-dot component mid-path", destination: "/mnt/usb/../etc", wantCode: http.StatusBadRequest, wantErrMsg: "Недопустимый путь destination"},
+		{name: "dot-dot component at start", destination: "/../etc/passwd", wantCode: http.StatusBadRequest, wantErrMsg: "Недопустимый путь destination"},
+		{name: "only dot-dot", destination: "/mnt/../../etc", wantCode: http.StatusBadRequest, wantErrMsg: "Недопустимый путь destination"},
 		// Acceptance cases — must not be rejected by validation
 		{name: "valid absolute path", destination: "/mnt/usb", wantCode: http.StatusOK},
 		{name: "trailing slash is normalised", destination: "/mnt/usb/", wantCode: http.StatusOK},
@@ -927,6 +928,16 @@ func TestHandleConfigurationUpdateDestinationValidation(t *testing.T) {
 			if w.Code != tc.wantCode {
 				t.Errorf("destination %q: expected HTTP %d, got %d (body: %s)",
 					tc.destination, tc.wantCode, w.Code, w.Body.String())
+			}
+			if tc.wantErrMsg != "" {
+				var resp APIResponse
+				if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+					t.Fatalf("failed to decode response: %v", err)
+				}
+				if resp.ErrMsg != tc.wantErrMsg {
+					t.Errorf("destination %q: expected error message %q, got %q",
+						tc.destination, tc.wantErrMsg, resp.ErrMsg)
+				}
 			}
 		})
 	}
@@ -998,9 +1009,7 @@ func TestHandleConfigurationUpdateDestinationNormalised(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read updated service file: %v", err)
 	}
-	if !strings.Contains(string(updatedService), "/src/ /mnt/usb/data\n") &&
-		!strings.Contains(string(updatedService), "/src/ /mnt/usb/data ") &&
-		!strings.HasSuffix(strings.TrimSpace(string(updatedService)), "/src/ /mnt/usb/data") {
+	if !strings.Contains(string(updatedService), "/src/ /mnt/usb/data") {
 		t.Errorf("expected service file to contain cleaned destination /mnt/usb/data (no trailing slash), got:\n%s", string(updatedService))
 	}
 	if strings.Contains(string(updatedService), "/mnt/usb/data/") {

--- a/internal/agent/menu_test.go
+++ b/internal/agent/menu_test.go
@@ -454,7 +454,7 @@ WantedBy = multi-user.target
 		t.Fatalf("failed to read updated service file: %v", err)
 	}
 
-	if !strings.Contains(string(updatedService), "/mnt/ya.disk/playlist/test/ /mnt/usb/playlist/") {
+	if !strings.Contains(string(updatedService), "/mnt/ya.disk/playlist/test/ /mnt/usb/playlist") {
 		t.Fatalf("updated service file does not contain new paths: %s", string(updatedService))
 	}
 
@@ -650,7 +650,7 @@ func TestHandleConfigurationUpdateEmptySourceUsesDefault(t *testing.T) {
 		t.Fatalf("failed to read updated service file: %v", err)
 	}
 
-	if !strings.Contains(string(updatedService), "media-pi.core server /mnt/usb/test/") {
+	if !strings.Contains(string(updatedService), "media-pi.core server /mnt/usb/test") {
 		t.Errorf("expected default source 'media-pi.core server' in service file, got: %s", string(updatedService))
 	}
 
@@ -849,6 +849,168 @@ func TestHandleConfigurationUploadRejectsInvalidRestIntervals(t *testing.T) {
 
 	if writeCalled {
 		t.Fatalf("crontab write should not be called on invalid data")
+	}
+}
+
+func TestHandleConfigurationUpdateDestinationValidation(t *testing.T) {
+	ServerKey = "test-key"
+
+	cases := []struct {
+		name        string
+		destination string
+		wantCode    int
+	}{
+		// Rejection cases
+		{name: "relative path", destination: "relative/path", wantCode: http.StatusBadRequest},
+		{name: "dot-dot component mid-path", destination: "/mnt/usb/../etc", wantCode: http.StatusBadRequest},
+		{name: "dot-dot component at start", destination: "/../etc/passwd", wantCode: http.StatusBadRequest},
+		{name: "only dot-dot", destination: "/mnt/../../etc", wantCode: http.StatusBadRequest},
+		// Acceptance cases — must not be rejected by validation
+		{name: "valid absolute path", destination: "/mnt/usb", wantCode: http.StatusOK},
+		{name: "trailing slash is normalised", destination: "/mnt/usb/", wantCode: http.StatusOK},
+		{name: "three-dot directory name", destination: "/mnt/.../data", wantCode: http.StatusOK},
+		{name: "dotdot-prefix directory name", destination: "/mnt/..cache/data", wantCode: http.StatusOK},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			servicePath := filepath.Join(tmp, "playlist.upload.service")
+			originalService := PlaylistServicePath
+			originalPlaylist := PlaylistTimerPath
+			originalVideo := VideoTimerPath
+			originalAudio := AudioConfigPath
+			originalCfgPath := ConfigPath
+			PlaylistServicePath = servicePath
+			PlaylistTimerPath = filepath.Join(tmp, "playlist.upload.timer")
+			VideoTimerPath = filepath.Join(tmp, "video.upload.timer")
+			AudioConfigPath = filepath.Join(tmp, "asound.conf")
+			ConfigPath = filepath.Join(tmp, "agent.yaml")
+			t.Cleanup(func() {
+				PlaylistServicePath = originalService
+				PlaylistTimerPath = originalPlaylist
+				VideoTimerPath = originalVideo
+				AudioConfigPath = originalAudio
+				ConfigPath = originalCfgPath
+			})
+
+			if err := os.WriteFile(servicePath, []byte("[Service]\nExecStart = /usr/bin/rsync /a /b"), 0644); err != nil {
+				t.Fatalf("failed to seed service file: %v", err)
+			}
+
+			config := Config{
+				ServerKey:  "test-key",
+				ListenAddr: "0.0.0.0:8081",
+				Playlist:   PlaylistConfig{Destination: "/mnt/usb"},
+				Audio:      AudioConfig{Output: "hdmi"},
+			}
+			configMutex.Lock()
+			currentConfig = &config
+			configMutex.Unlock()
+
+			originalRead := CrontabReadFunc
+			originalWrite := CrontabWriteFunc
+			CrontabReadFunc = func() (string, error) { return "", nil }
+			CrontabWriteFunc = func(string) error { return nil }
+			t.Cleanup(func() {
+				CrontabReadFunc = originalRead
+				CrontabWriteFunc = originalWrite
+			})
+
+			body := `{"playlist":{"source":"src","destination":"` + tc.destination + `"},"schedule":{"playlist":["08:00"],"video":["12:00"],"rest":[]},"audio":{"output":"hdmi"}}`
+			req := httptest.NewRequest(http.MethodPut, "/api/menu/configuration/update", strings.NewReader(body))
+			req.Header.Set("Authorization", "Bearer test-key")
+			w := httptest.NewRecorder()
+
+			HandleConfigurationUpdate(w, req)
+
+			if w.Code != tc.wantCode {
+				t.Errorf("destination %q: expected HTTP %d, got %d (body: %s)",
+					tc.destination, tc.wantCode, w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+// TestHandleConfigurationUpdateDestinationNormalised verifies that a trailing-slash
+// destination is written to the service file and agent.yaml using the canonical
+// (cleaned) path without the trailing slash.
+func TestHandleConfigurationUpdateDestinationNormalised(t *testing.T) {
+	ServerKey = "test-key"
+
+	tmp := t.TempDir()
+	servicePath := filepath.Join(tmp, "playlist.upload.service")
+	originalService := PlaylistServicePath
+	originalPlaylist := PlaylistTimerPath
+	originalVideo := VideoTimerPath
+	originalAudio := AudioConfigPath
+	originalCfgPath := ConfigPath
+	PlaylistServicePath = servicePath
+	PlaylistTimerPath = filepath.Join(tmp, "playlist.upload.timer")
+	VideoTimerPath = filepath.Join(tmp, "video.upload.timer")
+	AudioConfigPath = filepath.Join(tmp, "asound.conf")
+	ConfigPath = filepath.Join(tmp, "agent.yaml")
+	t.Cleanup(func() {
+		PlaylistServicePath = originalService
+		PlaylistTimerPath = originalPlaylist
+		VideoTimerPath = originalVideo
+		AudioConfigPath = originalAudio
+		ConfigPath = originalCfgPath
+	})
+
+	if err := os.WriteFile(servicePath, []byte("[Service]\nExecStart = /usr/bin/rsync /old/src /old/dst"), 0644); err != nil {
+		t.Fatalf("failed to seed service file: %v", err)
+	}
+
+	config := Config{
+		ServerKey:  "test-key",
+		ListenAddr: "0.0.0.0:8081",
+		Playlist:   PlaylistConfig{Destination: "/mnt/usb"},
+		Audio:      AudioConfig{Output: "hdmi"},
+	}
+	configMutex.Lock()
+	currentConfig = &config
+	configMutex.Unlock()
+
+	originalRead := CrontabReadFunc
+	originalWrite := CrontabWriteFunc
+	CrontabReadFunc = func() (string, error) { return "", nil }
+	CrontabWriteFunc = func(string) error { return nil }
+	t.Cleanup(func() {
+		CrontabReadFunc = originalRead
+		CrontabWriteFunc = originalWrite
+	})
+
+	// Destination has a trailing slash — it should be stored and written without it.
+	body := `{"playlist":{"source":"/src/","destination":"/mnt/usb/data/"},"schedule":{"playlist":["08:00"],"video":["12:00"],"rest":[]},"audio":{"output":"hdmi"}}`
+	req := httptest.NewRequest(http.MethodPut, "/api/menu/configuration/update", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-key")
+	w := httptest.NewRecorder()
+
+	HandleConfigurationUpdate(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Service file must use the cleaned destination (no trailing slash).
+	updatedService, err := os.ReadFile(servicePath)
+	if err != nil {
+		t.Fatalf("failed to read updated service file: %v", err)
+	}
+	if !strings.Contains(string(updatedService), "/src/ /mnt/usb/data\n") &&
+		!strings.Contains(string(updatedService), "/src/ /mnt/usb/data ") &&
+		!strings.HasSuffix(strings.TrimSpace(string(updatedService)), "/src/ /mnt/usb/data") {
+		t.Errorf("expected service file to contain cleaned destination /mnt/usb/data (no trailing slash), got:\n%s", string(updatedService))
+	}
+	if strings.Contains(string(updatedService), "/mnt/usb/data/") {
+		t.Errorf("service file must not contain destination with trailing slash, got:\n%s", string(updatedService))
+	}
+
+	// agent.yaml must also use the cleaned destination.
+	cfg := GetCurrentConfig()
+	if cfg.Playlist.Destination != "/mnt/usb/data" {
+		t.Errorf("expected config destination /mnt/usb/data, got %q", cfg.Playlist.Destination)
 	}
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/sw-consulting/media-pi.device/security/code-scanning/6](https://github.com/sw-consulting/media-pi.device/security/code-scanning/6)

To fix this safely without changing intended behavior, validate and constrain `playlist.destination` at configuration update time so it can only point to an allowed directory subtree (or to a safe absolute directory policy). The best single fix in the shown code is:

1. In `internal/agent/menu.go`, after reading `playlistDestination`, canonicalize and validate it.
2. Reject empty/invalid values and reject paths that are not absolute and normalized without traversal (`..`).
3. Persist only the cleaned canonical path.

Given only shown snippets can be edited, the least invasive robust fix is to enforce:
- destination must be an absolute path (`filepath.IsAbs`)
- cleaned path (`filepath.Clean`) must not contain `..` path segments
- use the cleaned path for `UpdateConfigSettings`

This blocks path traversal and relative-path abuse before tainted data enters runtime sync logic.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
