### PR TITLE
Potential fix for code scanning alert no. 17: Uncontrolled data used in path expression

### DIFF
--- a/internal/agent/menu.go
+++ b/internal/agent/menu.go
@@ -668,6 +668,23 @@ func HandleConfigurationUpdate(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	const playlistBaseDir = "/var/media-pi"
+	baseAbs, err := filepath.Abs(playlistBaseDir)
+	if err != nil {
+		JSONResponse(w, http.StatusInternalServerError, APIResponse{OK: false, ErrMsg: "Не удалось проверить путь destination"})
+		return
+	}
+	destAbs, err := filepath.Abs(cleanDestination)
+	if err != nil {
+		JSONResponse(w, http.StatusBadRequest, APIResponse{OK: false, ErrMsg: "Недопустимый путь destination"})
+		return
+	}
+	basePrefix := baseAbs + string(os.PathSeparator)
+	if destAbs != baseAbs && !strings.HasPrefix(destAbs, basePrefix) {
+		JSONResponse(w, http.StatusBadRequest, APIResponse{OK: false, ErrMsg: "Недопустимый путь destination"})
+		return
+	}
+	cleanDestination = destAbs
 
 	if hasInvalidTimes(req.Schedule.Playlist, req.Schedule.Video) {
 		JSONResponse(w, http.StatusBadRequest, APIResponse{OK: false, ErrMsg: "Неверный формат времени. Используйте HH:MM"})


### PR DESCRIPTION
Potential fix for [https://github.com/sw-consulting/media-pi.device/security/code-scanning/17](https://github.com/sw-consulting/media-pi.device/security/code-scanning/17)

To fix this safely without changing core functionality (still allowing configurable subdirectories), validate that `playlistDestination` resolves under a fixed safe base directory before saving it. The best place is in `HandleConfigurationUpdate` (input validation boundary), and optionally enforce again at use sites for defense-in-depth.  
For the shown code, update `internal/agent/menu.go` where `cleanDestination` is computed:

- Define a constant safe base dir (for example `/var/media-pi`).
- Resolve both safe base and candidate destination to absolute, cleaned paths.
- Reject if destination is not equal to base and not under `base + path separator`.
- Keep storing the validated absolute path (`cleanDestination`) in config as before.

This prevents traversal and arbitrary absolute path selection while preserving intended behavior of writing playlists into configurable folders under the application directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
