### PR TITLE
Potential fix for code scanning alert no. 18: Uncontrolled data used in path expression

### DIFF
--- a/internal/agent/menu.go
+++ b/internal/agent/menu.go
@@ -668,6 +668,21 @@ func HandleConfigurationUpdate(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	safePlaylistBase := filepath.Clean("/var/media-pi")
+	absSafePlaylistBase, err := filepath.Abs(safePlaylistBase)
+	if err != nil {
+		JSONResponse(w, http.StatusInternalServerError, APIResponse{OK: false, ErrMsg: "Не удалось проверить путь destination"})
+		return
+	}
+	absDestination, err := filepath.Abs(cleanDestination)
+	if err != nil {
+		JSONResponse(w, http.StatusBadRequest, APIResponse{OK: false, ErrMsg: "Недопустимый путь destination"})
+		return
+	}
+	if absDestination != absSafePlaylistBase && !strings.HasPrefix(absDestination, absSafePlaylistBase+string(os.PathSeparator)) {
+		JSONResponse(w, http.StatusBadRequest, APIResponse{OK: false, ErrMsg: "Недопустимый путь destination"})
+		return
+	}
 
 	if hasInvalidTimes(req.Schedule.Playlist, req.Schedule.Video) {
 		JSONResponse(w, http.StatusBadRequest, APIResponse{OK: false, ErrMsg: "Неверный формат времени. Используйте HH:MM"})
@@ -746,7 +761,7 @@ func HandleConfigurationUpdate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := UpdateConfigSettings(
-		PlaylistConfig{Source: playlistSource, Destination: cleanDestination},
+		PlaylistConfig{Source: playlistSource, Destination: absDestination},
 		ScheduleConfig{Playlist: normalizedPlaylist, Video: normalizedVideo, Rest: restConfigPairs},
 		AudioConfig{Output: req.Audio.Output},
 		ScreenshotConfig{


### PR DESCRIPTION
Potential fix for [https://github.com/sw-consulting/media-pi.device/security/code-scanning/18](https://github.com/sw-consulting/media-pi.device/security/code-scanning/18)

General fix: enforce a strict allowlist boundary for playlist destination paths (for example, under `/var/media-pi`) at input-validation time, and reject anything outside that base. Use canonical absolute paths and boundary-safe prefix checks.

Best single fix without changing intended behavior: in `internal/agent/menu.go` inside `HandleConfigurationUpdate`, after existing clean/abs/`..` checks, add a containment check ensuring `cleanDestination` resolves under a fixed safe base directory (e.g. `/var/media-pi`). Use:
- `safeBase := filepath.Clean("/var/media-pi")`
- `absSafeBase, _ := filepath.Abs(safeBase)`
- `absDestination, _ := filepath.Abs(cleanDestination)`
- allow only if `absDestination == absSafeBase` or `strings.HasPrefix(absDestination, absSafeBase + string(os.PathSeparator))`

Then store `absDestination` in config (instead of `cleanDestination`) when calling `UpdateConfigSettings`.

This addresses the taint flow at the source and keeps `sync.go` filesystem operations safe without changing sync logic.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
